### PR TITLE
Remove non-ascii chars from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ RoboHash
 The source code for `RoboHash.org`_.
 
 It basically copy/pastes various robot pictures together, using bits
-from the SHA hash. It’s not perfect, and not entirely secure, but it
-gives a good gut-check to “Hey, this SHA is wrong.”
+from the SHA hash. It's not perfect, and not entirely secure, but it
+gives a good gut-check to "Hey, this SHA is wrong."
 
 Install
 -------
@@ -38,13 +38,13 @@ Usage
 Robosets
 --------
 
-RoboHash comes with three image sets, named “set1”, “set2”, and “set3”.
+RoboHash comes with three image sets, named "set1", "set2", and "set3".
 Specify which set you want in the ``assemble()`` method. Alternatively,
-specify the string “any”, and RoboHash will pick an image set for you,
+specify the string "any", and RoboHash will pick an image set for you,
 based on the provided hash.
 
-The “set1” artwork was created by Zikri Kader. The “set2” artwork was
-created by Hrvoje Novakovic. The “set3” artwork was created by Julian
+The "set1" artwork was created by Zikri Kader. The "set2" artwork was
+created by Hrvoje Novakovic. The "set3" artwork was created by Julian
 Peter Arias.
 The Cats/"set4" were created by David Revoy, used under CC-BY-4.0
 https://www.peppercarrot.com/en/article391/cat-avatar-generator
@@ -62,8 +62,8 @@ The RoboHash images are available under the CC-BY-3.0 license.
 Disclaimer
 ----------
 
-OK, I’ll admit I’m a crappy programmer. Compounding this, I wrote this
-code initially to be internal-only. It’s ugly, and could be a LOT nicer.
+OK, I'll admit I'm a crappy programmer. Compounding this, I wrote this
+code initially to be internal-only. It's ugly, and could be a LOT nicer.
 
 Sorry about that.
 


### PR DESCRIPTION
Some pip versions have problems with non-ascii characters and will throw something like this:

```
  Cloning https://github.com/e1ven/Robohash.git to /tmp/pip-req-build-d29khsw9
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-d29khsw9/setup.py", line 7, in <module>
        long_description = file.read()
      File "/tmp/.virtualenv/lib64/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 147: ordinal not in range(128)
```