### PR TITLE
Migrate Image.ANTIALIAS to Image.LANCZOS to support Pillow>=10.0.0

### DIFF
--- a/robohash/robohash.py
+++ b/robohash/robohash.py
@@ -195,6 +195,6 @@ class Robohash(object):
                 r, g, b, a = roboimg.split()
                 roboimg = Image.merge("RGB", (r, g, b))
 
-        self.img = roboimg.resize((sizex,sizey),Image.ANTIALIAS)
+        self.img = roboimg.resize((sizex,sizey),Image.LANCZOS)
         self.format = format
 


### PR DESCRIPTION
Image.ANTIALIAS has been removed in Pillow >= 10.0.0

Reference: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants
